### PR TITLE
Fix Swift 6.2 concurrency: add @unchecked Sendable to Fluent models, …

### DIFF
--- a/Sources/App/DBServices/AddDatabaseIndices.swift
+++ b/Sources/App/DBServices/AddDatabaseIndices.swift
@@ -1,40 +1,26 @@
 import Fluent
+import FluentSQL
 
 struct AddDatabaseIndices: AsyncMigration {
     func prepare(on database: Database) async throws {
-        // Index on feeds.url for endpoint lookups
-        try await database.schema("feeds")
-            .unique(on: "url")
-            .update()
+        guard let sql = database as? SQLDatabase else { return }
 
-        // Index on trips.feed_id and trips.headsign for filtered queries
-        try await database.schema("trips")
-            .unique(on: "trip_id", "feed_id")
-            .update()
-
-        // Index on stops.feed_id and stops.stop_id for lookups
-        try await database.schema("stops")
-            .unique(on: "stop_id", "feed_id")
-            .update()
-
-        // Index on stop_times.trip_id for join queries
-        try await database.schema("stop_times")
-            .unique(on: "trip_id", "stop_id", "stop_sequence", "feed_id")
-            .update()
-
-        // Index on calendar_dates for service_id filtering
-        try await database.schema("calendar_dates")
-            .unique(on: "service_id", "date", "feed_id")
-            .update()
-
-        // Index on agencies.feed_id
-        try await database.schema("agencies")
-            .unique(on: "agency_id", "feed_id")
-            .update()
+        try await sql.raw("CREATE UNIQUE INDEX IF NOT EXISTS idx_feeds_url ON feeds(url)").run()
+        try await sql.raw("CREATE UNIQUE INDEX IF NOT EXISTS idx_trips_trip_feed ON trips(trip_id, feed_id)").run()
+        try await sql.raw("CREATE UNIQUE INDEX IF NOT EXISTS idx_stops_stop_feed ON stops(stop_id, feed_id)").run()
+        try await sql.raw("CREATE UNIQUE INDEX IF NOT EXISTS idx_stop_times_composite ON stop_times(trip_id, stop_id, stop_sequence, feed_id)").run()
+        try await sql.raw("CREATE UNIQUE INDEX IF NOT EXISTS idx_calendar_dates_composite ON calendar_dates(service_id, date, feed_id)").run()
+        try await sql.raw("CREATE UNIQUE INDEX IF NOT EXISTS idx_agencies_agency_feed ON agencies(agency_id, feed_id)").run()
     }
 
     func revert(on database: Database) async throws {
-        // SQLite doesn't support dropping individual constraints easily,
-        // so reverting would require recreating tables.
+        guard let sql = database as? SQLDatabase else { return }
+
+        try await sql.raw("DROP INDEX IF EXISTS idx_feeds_url").run()
+        try await sql.raw("DROP INDEX IF EXISTS idx_trips_trip_feed").run()
+        try await sql.raw("DROP INDEX IF EXISTS idx_stops_stop_feed").run()
+        try await sql.raw("DROP INDEX IF EXISTS idx_stop_times_composite").run()
+        try await sql.raw("DROP INDEX IF EXISTS idx_calendar_dates_composite").run()
+        try await sql.raw("DROP INDEX IF EXISTS idx_agencies_agency_feed").run()
     }
 }

--- a/Sources/App/DBServices/AgencyRecord.swift
+++ b/Sources/App/DBServices/AgencyRecord.swift
@@ -9,7 +9,7 @@ import Fluent
 import LocomoSwift
 import Vapor
 
-final class AgencyRecord: Model, Content {
+final class AgencyRecord: Model, Content, @unchecked Sendable {
     static let schema = "agencies"
 
     @ID(key: .id)

--- a/Sources/App/DBServices/CalendarDatesRecord.swift
+++ b/Sources/App/DBServices/CalendarDatesRecord.swift
@@ -15,7 +15,7 @@ import Vapor
 /// a service operates or not on particular dates.
 ///
 /// - Note: The exception_type value of 1 indicates service is added, while 2 indicates service removal
-final class CalendarDateRecord: Model, Content {
+final class CalendarDateRecord: Model, Content, @unchecked Sendable {
     static let schema = "calendar_dates"
     
     /// The unique identifier for this calendar date record

--- a/Sources/App/DBServices/FeedRecord.swift
+++ b/Sources/App/DBServices/FeedRecord.swift
@@ -9,7 +9,7 @@
 import Fluent
 import Vapor
 
-final class FeedRecord: Model, Content {
+final class FeedRecord: Model, Content, @unchecked Sendable {
     static let schema = "feeds"  // Nom de la table dans la base de données
 
     @ID(key: .id)

--- a/Sources/App/DBServices/StopRecord.swift
+++ b/Sources/App/DBServices/StopRecord.swift
@@ -10,7 +10,7 @@ import Fluent
 import Vapor
 import LocomoSwift
 
-final class StopRecord: Model, Content {
+final class StopRecord: Model, Content, @unchecked Sendable {
     static let schema = "stops"
     
     @ID(key: .id)

--- a/Sources/App/DBServices/StopTimesRecord.swift
+++ b/Sources/App/DBServices/StopTimesRecord.swift
@@ -10,7 +10,7 @@ import Fluent
 import Vapor
 import LocomoSwift
 
-final class StopTimeRecord: Model, Content {
+final class StopTimeRecord: Model, Content, @unchecked Sendable {
     static let schema = "stop_times"
     
     @ID(key: .id)

--- a/Sources/App/DBServices/TripRecord.swift
+++ b/Sources/App/DBServices/TripRecord.swift
@@ -10,7 +10,7 @@ import Fluent
 import LocomoSwift
 import Vapor
 
-final class TripRecord: Model, Content {
+final class TripRecord: Model, Content, @unchecked Sendable {
     typealias IDValue = String
     
     static let schema = "trips"


### PR DESCRIPTION
…fix SQLite indices

- Add @unchecked Sendable to all 6 Fluent model classes (Fluent handles thread safety internally but property wrappers are mutable)
- Rewrite AddDatabaseIndices migration to use raw SQL CREATE UNIQUE INDEX instead of Fluent schema builder, which SQLite doesn't support for ALTER TABLE